### PR TITLE
Faster, and offline venvs

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -10,8 +10,9 @@ mkdir "%yenpath%" 2>nul
 REM Download yen executable and save it to the .yen\bin directory
 SET "download_url=https://github.com/tusharsadhwani/yen/releases/latest/download/yen-rs-x86_64-pc-windows-msvc.exe"
 curl -SL --progress-bar "%download_url%" --output "%yenpath%\yen.exe"
-REM Download userpath too
+REM Download userpath and microvenv too
 curl -SL --progress-bar "https://yen.tushar.lol/userpath.pyz" --output "%yenpath%\userpath.pyz"
+curl -SL --progress-bar "https://yen.tushar.lol/microvenv.py" --output "%yenpath%\microvenv.py"
 
 REM Get the user's PATH without the system-wide PATH
 for /f "skip=2 tokens=2,*" %%A in ('reg query HKCU\Environment /v PATH') do (

--- a/install.ps1
+++ b/install.ps1
@@ -9,8 +9,9 @@ if (-not (Test-Path $yenpath)) {
 # Download yen executable and save it to the .yen\bin directory
 $downloadUrl = "https://github.com/tusharsadhwani/yen/releases/latest/download/yen-rs-x86_64-pc-windows-msvc.exe"
 Invoke-WebRequest -Uri $downloadUrl -OutFile "$yenpath\yen.exe"
-# Download userpath too
+# Download userpath and microvenv too
 Invoke-WebRequest -Uri "https://yen.tushar.lol/userpath.pyz" -OutFile "$yenpath\userpath.pyz"
+Invoke-WebRequest -Uri "https://yen.tushar.lol/microvenv.py" -OutFile "$yenpath\microvenv.py"
 
 # Get the user's PATH without the system-wide PATH
 $userPath = (Get-ItemProperty -Path 'HKCU:\Environment' -Name 'Path').Path

--- a/install.sh
+++ b/install.sh
@@ -46,9 +46,9 @@ fi
 
 # Move yen to the install directory
 mkdir -p "$INSTALL_DIR"
-cp "$TEMP_FILE" "$INSTALL_DIR/yen"
+mv "$TEMP_FILE" "$INSTALL_DIR/yen"
 
-# Download userpath too
+# Download userpath and microvenv too
 USERPATH_URL="https://yen.tushar.lol/userpath.pyz"
 HTTP_CODE=$(curl -SL --progress-bar "$USERPATH_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
 if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
@@ -56,7 +56,16 @@ if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
   exit 1
 fi
 mkdir -p "$INSTALL_DIR"
-cp "$TEMP_FILE" "$INSTALL_DIR/userpath.pyz"
+mv "$TEMP_FILE" "$INSTALL_DIR/userpath.pyz"
+
+MICROVENV_URL="https://yen.tushar.lol/microvenv.py"
+HTTP_CODE=$(curl -SL --progress-bar "$MICROVENV_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
+if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
+  echo "error: '${MICROVENV_URL}' is not available"
+  exit 1
+fi
+mkdir -p "$INSTALL_DIR"
+mv "$TEMP_FILE" "$INSTALL_DIR/microvenv.py"
 
 
 update_shell() {

--- a/src/yen/__init__.py
+++ b/src/yen/__init__.py
@@ -26,6 +26,7 @@ PACKAGE_INSTALLS_PATH = os.path.abspath(
 )
 
 USERPATH_PATH = os.path.join(YEN_BIN_PATH, "userpath.pyz")
+MICROVENV_PATH = os.path.join(YEN_BIN_PATH, "microvenv.py")
 
 DEFAULT_PYTHON_VERSION = "3.12"
 
@@ -60,6 +61,15 @@ def _ensure_userpath() -> None:
 
     os.makedirs(YEN_BIN_PATH, exist_ok=True)
     urlretrieve("http://yen.tushar.lol/userpath.pyz", filename=USERPATH_PATH)
+
+
+def _ensure_microvenv() -> None:
+    """Downloads `microvenv.py`, if it doesn't exist in `YEN_BIN_PATH`."""
+    if os.path.exists(MICROVENV_PATH):
+        return
+
+    os.makedirs(YEN_BIN_PATH, exist_ok=True)
+    urlretrieve("http://yen.tushar.lol/microvenv.py", filename=MICROVENV_PATH)
 
 
 def find_or_download_python() -> str:
@@ -137,9 +147,8 @@ def ensure_python(python_version: str) -> tuple[str, str]:
 
 
 def create_venv(python_bin_path: str, venv_path: str) -> None:
-    # TODO: bundle microvenv.pyz as a dependency, venv is genuinely too slow
-    # microvenv doesn't support windows, fallback to venv for that. teehee.
-    subprocess.run([python_bin_path, "-m", "venv", venv_path], check=True)
+    _ensure_microvenv()
+    subprocess.run([python_bin_path, MICROVENV_PATH, venv_path], check=True)
 
 
 def _venv_binary_path(binary_name: str, venv_path: str) -> str:

--- a/src/yen/__init__.py
+++ b/src/yen/__init__.py
@@ -149,6 +149,7 @@ def ensure_python(python_version: str) -> tuple[str, str]:
 def create_venv(python_bin_path: str, venv_path: str) -> None:
     if platform.system() == "Windows":
         subprocess.run([python_bin_path, "-m", "venv", venv_path], check=True)
+        return
 
     _ensure_microvenv()
     subprocess.run([python_bin_path, MICROVENV_PATH, venv_path], check=True)

--- a/src/yen/__init__.py
+++ b/src/yen/__init__.py
@@ -147,6 +147,9 @@ def ensure_python(python_version: str) -> tuple[str, str]:
 
 
 def create_venv(python_bin_path: str, venv_path: str) -> None:
+    if platform.system() == "Windows":
+        subprocess.run([python_bin_path, "-m", "venv", venv_path], check=True)
+
     _ensure_microvenv()
     subprocess.run([python_bin_path, MICROVENV_PATH, venv_path], check=True)
     venv_python_path = _venv_binary_path("python", venv_path)

--- a/src/yen/__init__.py
+++ b/src/yen/__init__.py
@@ -206,17 +206,11 @@ def install_package(
     create_venv(python_bin_path, venv_path)
 
     venv_python_path = _venv_binary_path("python", venv_path)
-    try:
-        subprocess.run(
-            [venv_python_path, "-m", "pip", "install", package_name],
-            check=True,
-            capture_output=True,
-        )
-    except subprocess.CalledProcessError as exc:
-        print(exc.stdout.decode())
-        print("---")
-        print(exc.stderr.decode())
-        raise
+    subprocess.run(
+        [venv_python_path, "-m", "pip", "install", package_name],
+        check=True,
+        capture_output=True,
+    )
 
     if is_module:
         with open(shim_path, "w") as file:

--- a/src/yen/__init__.py
+++ b/src/yen/__init__.py
@@ -110,13 +110,15 @@ def ensure_python(python_version: str) -> tuple[str, str]:
     """Checks if given Python version exists locally. If not, downloads it."""
     os.makedirs(PYTHON_INSTALLS_PATH, exist_ok=True)
 
+    for python_folder_name in os.listdir(PYTHON_INSTALLS_PATH):
+        python_folder = os.path.join(PYTHON_INSTALLS_PATH, python_folder_name)
+        if python_folder_name.startswith(python_version):
+            # already installed
+            python_bin_path = _python_bin_path(python_folder)
+            return python_folder_name, python_bin_path
+
     python_version, download_link = resolve_python_version(python_version)
     download_directory = os.path.join(PYTHON_INSTALLS_PATH, python_version)
-
-    python_bin_path = _python_bin_path(download_directory)
-    if os.path.exists(python_bin_path):
-        # already installed
-        return python_version, python_bin_path
 
     os.makedirs(download_directory, exist_ok=True)
     downloaded_filepath = download(
@@ -141,8 +143,9 @@ def ensure_python(python_version: str) -> tuple[str, str]:
         tar.extractall(download_directory)
 
     os.remove(downloaded_filepath)
-    assert os.path.exists(python_bin_path)
 
+    python_bin_path = _python_bin_path(download_directory)
+    assert os.path.exists(python_bin_path)
     return python_version, python_bin_path
 
 

--- a/yen-rs/src/commands/create.rs
+++ b/yen-rs/src/commands/create.rs
@@ -5,7 +5,7 @@ use miette::IntoDiagnostic;
 
 use crate::{
     github::Version,
-    utils::{_ensure_microvenv, _venv_binary_path, ensure_python},
+    utils::{_ensure_microvenv, _venv_binary_path, ensure_python, IS_WINDOWS},
     MICROVENV_PATH,
 };
 
@@ -27,14 +27,21 @@ pub async fn create_env(python_bin_path: PathBuf, venv_path: &PathBuf) -> miette
         miette::bail!("Error: {} already exists!", venv_path.to_string_lossy());
     }
 
-    _ensure_microvenv().await?;
-    let stdout = Command::new(format!("{}", python_bin_path.to_string_lossy()))
-        .args([
-            &MICROVENV_PATH.to_string_lossy().into_owned(),
-            &venv_path.to_string_lossy().into_owned(),
-        ])
-        .output()
-        .into_diagnostic()?;
+    let stdout = if IS_WINDOWS {
+        Command::new(format!("{}", python_bin_path.to_string_lossy()))
+            .args(["-m", "venv", &format!("{}", venv_path.to_string_lossy())])
+            .output()
+            .into_diagnostic()?
+    } else {
+        _ensure_microvenv().await?;
+        Command::new(format!("{}", python_bin_path.to_string_lossy()))
+            .args([
+                &MICROVENV_PATH.to_string_lossy().into_owned(),
+                &venv_path.to_string_lossy().into_owned(),
+            ])
+            .output()
+            .into_diagnostic()?
+    };
 
     if !stdout.status.success() {
         miette::bail!(format!(
@@ -44,18 +51,20 @@ pub async fn create_env(python_bin_path: PathBuf, venv_path: &PathBuf) -> miette
         ));
     }
 
-    let venv_python_path = _venv_binary_path("python", venv_path);
-    let stdout = Command::new(format!("{}", venv_python_path.to_string_lossy()))
-        .args(["-m", "ensurepip"])
-        .output()
-        .into_diagnostic()?;
+    if !IS_WINDOWS {
+        let venv_python_path = _venv_binary_path("python", venv_path);
+        let stdout = Command::new(format!("{}", venv_python_path.to_string_lossy()))
+            .args(["-m", "ensurepip"])
+            .output()
+            .into_diagnostic()?;
 
-    if !stdout.status.success() {
-        miette::bail!(format!(
-            "Error: unable to run ensurepip!\nStdout: {}\nStderr: {}",
-            String::from_utf8_lossy(&stdout.stdout),
-            String::from_utf8_lossy(&stdout.stderr),
-        ));
+        if !stdout.status.success() {
+            miette::bail!(format!(
+                "Error: unable to run ensurepip!\nStdout: {}\nStderr: {}",
+                String::from_utf8_lossy(&stdout.stdout),
+                String::from_utf8_lossy(&stdout.stderr),
+            ));
+        }
     }
 
     Ok(())

--- a/yen-rs/src/commands/create.rs
+++ b/yen-rs/src/commands/create.rs
@@ -3,7 +3,11 @@ use std::{path::PathBuf, process::Command};
 use clap::Parser;
 use miette::IntoDiagnostic;
 
-use crate::{github::Version, utils::ensure_python};
+use crate::{
+    github::Version,
+    utils::{_ensure_microvenv, ensure_python},
+    MICROVENV_PATH,
+};
 
 /// Create venv with python version
 #[derive(Parser, Debug)]
@@ -23,8 +27,12 @@ pub async fn create_env(python_bin_path: PathBuf, venv_path: &PathBuf) -> miette
         miette::bail!("Error: {} already exists!", venv_path.to_string_lossy());
     }
 
+    _ensure_microvenv().await?;
     let stdout = Command::new(format!("{}", python_bin_path.to_string_lossy()))
-        .args(["-m", "venv", &format!("{}", venv_path.to_string_lossy())])
+        .args([
+            &MICROVENV_PATH.to_string_lossy().into_owned(),
+            &venv_path.to_string_lossy().into_owned(),
+        ])
         .output()
         .into_diagnostic()?;
 

--- a/yen-rs/src/commands/create.rs
+++ b/yen-rs/src/commands/create.rs
@@ -45,14 +45,14 @@ pub async fn create_env(python_bin_path: PathBuf, venv_path: &PathBuf) -> miette
     }
 
     let venv_python_path = _venv_binary_path("python", venv_path);
-    let stdout = Command::new(format!("{}", python_bin_path.to_string_lossy()))
-        .args([&venv_python_path.to_string_lossy(), "-m", "ensurepip"])
+    let stdout = Command::new(format!("{}", venv_python_path.to_string_lossy()))
+        .args(["-m", "ensurepip"])
         .output()
         .into_diagnostic()?;
 
     if !stdout.status.success() {
         miette::bail!(format!(
-            "Error: unable to create venv!\nStdout: {}\nStderr: {}",
+            "Error: unable to run ensurepip!\nStdout: {}\nStderr: {}",
             String::from_utf8_lossy(&stdout.stdout),
             String::from_utf8_lossy(&stdout.stderr),
         ));

--- a/yen-rs/src/commands/install.rs
+++ b/yen-rs/src/commands/install.rs
@@ -5,16 +5,13 @@ use miette::IntoDiagnostic;
 
 use crate::{
     github::Version,
-    utils::{_ensure_userpath, ensure_python, find_or_download_python},
+    utils::{
+        _ensure_userpath, _venv_binary_path, ensure_python, find_or_download_python, IS_WINDOWS,
+    },
     DEFAULT_PYTHON_VERSION, PACKAGE_INSTALLS_PATH, USERPATH_PATH,
 };
 
 use super::create::create_env;
-
-#[cfg(target_os = "windows")]
-const IS_WINDOWS: bool = true;
-#[cfg(not(target_os = "windows"))]
-const IS_WINDOWS: bool = false;
 
 /// Install a Python package in an isolated environment.
 #[derive(Parser, Debug)]
@@ -99,16 +96,6 @@ async fn check_path(path: PathBuf) -> miette::Result<()> {
     }
 
     Ok(())
-}
-
-fn _venv_binary_path(binary_name: &str, venv_path: &std::path::PathBuf) -> std::path::PathBuf {
-    let venv_bin_path = venv_path.join(if IS_WINDOWS { "Scripts" } else { "bin" });
-    let binary_path = venv_bin_path.join(if IS_WINDOWS {
-        format!("{binary_name}.exe")
-    } else {
-        binary_name.to_string()
-    });
-    return binary_path;
 }
 
 pub async fn install_package(

--- a/yen-rs/src/main.rs
+++ b/yen-rs/src/main.rs
@@ -44,6 +44,7 @@ lazy_static! {
         .expect("Failed to turn YEN_BIN_PATH into absolute")
     };
     static ref USERPATH_PATH: PathBuf = YEN_BIN_PATH.join("userpath.pyz");
+    static ref MICROVENV_PATH: PathBuf = YEN_BIN_PATH.join("microvenv.py");
     static ref YEN_CLIENT: Client = yen_client();
 }
 

--- a/yen-rs/src/utils.rs
+++ b/yen-rs/src/utils.rs
@@ -16,7 +16,8 @@ use tar::Archive;
 
 use crate::{
     github::{resolve_python_version, Version},
-    DEFAULT_PYTHON_VERSION, PYTHON_INSTALLS_PATH, USERPATH_PATH, YEN_BIN_PATH, YEN_CLIENT,
+    DEFAULT_PYTHON_VERSION, MICROVENV_PATH, PYTHON_INSTALLS_PATH, USERPATH_PATH, YEN_BIN_PATH,
+    YEN_CLIENT,
 };
 
 #[cfg(target_os = "linux")]
@@ -92,6 +93,29 @@ pub async fn _ensure_userpath() -> miette::Result<()> {
         .into_diagnostic()?;
 
     std::fs::write(USERPATH_PATH.to_path_buf(), userpath_content).into_diagnostic()?;
+    Ok(())
+}
+
+/// Downloads `microvenv.py`, if it doesn't exist in `YEN_BIN_PATH`.
+pub async fn _ensure_microvenv() -> miette::Result<()> {
+    if MICROVENV_PATH.exists() {
+        return Ok(());
+    }
+
+    if !YEN_BIN_PATH.exists() {
+        std::fs::create_dir_all(YEN_BIN_PATH.to_path_buf()).into_diagnostic()?;
+    }
+
+    let microvenv_content = YEN_CLIENT
+        .get("https://yen.tushar.lol/microvenv.py")
+        .send()
+        .await
+        .into_diagnostic()?
+        .bytes()
+        .await
+        .into_diagnostic()?;
+
+    std::fs::write(MICROVENV_PATH.to_path_buf(), microvenv_content).into_diagnostic()?;
     Ok(())
 }
 


### PR DESCRIPTION
- Try to find a satisfyable Python version locally before trying to resolve it from GitHub.
- Fix fallback GitHub data not being used properly in Rust (Python venv creation would have worked offline until now as long as the Python version in the fallback github data matches local, Rust didn't, because when the http request failed it would bubble up the error.)
- Use the bundled `microvenv` with `python -m ensurepip` for macos and linux, which is much faster than the `venv` module.