### PR TITLE
feat: Add fallback to wget for installation script

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -7,12 +7,25 @@ SET "yenpath=%userprofile%\.yen\bin"
 REM Create the .yen\bin directory if it doesn't exist
 mkdir "%yenpath%" 2>nul
 
+REM Function to download using curl or wget
+:download
+if exist "%SystemRoot%\System32\curl.exe" (
+    curl -SL --progress-bar "%1" --output "%2"
+) else if exist "%SystemRoot%\System32\wget.exe" (
+    wget "%1" -O "%2"
+) else (
+    echo Neither curl nor wget is installed. Please install one of them and try again.
+    exit /b 1
+)
+goto :eof
+
 REM Download yen executable and save it to the .yen\bin directory
 SET "download_url=https://github.com/tusharsadhwani/yen/releases/latest/download/yen-rs-x86_64-pc-windows-msvc.exe"
-curl -SL --progress-bar "%download_url%" --output "%yenpath%\yen.exe"
+call :download "%download_url%" "%yenpath%\yen.exe"
+
 REM Download userpath and microvenv too
-curl -SL --progress-bar "https://yen.tushar.lol/userpath.pyz" --output "%yenpath%\userpath.pyz"
-curl -SL --progress-bar "https://yen.tushar.lol/microvenv.py" --output "%yenpath%\microvenv.py"
+call :download "https://yen.tushar.lol/userpath.pyz" "%yenpath%\userpath.pyz"
+call :download "https://yen.tushar.lol/microvenv.py" "%yenpath%\microvenv.py"
 
 REM Get the user's PATH without the system-wide PATH
 for /f "skip=2 tokens=2,*" %%A in ('reg query HKCU\Environment /v PATH') do (

--- a/install.sh
+++ b/install.sh
@@ -1,114 +1,116 @@
 #!/usr/bin/env bash
 
-# Copied from https://github.com/prefix-dev/pixi/blob/d8d2d8a/install/install.sh
-
 __wrap__() {
 
-INSTALL_DIR="$HOME/.yen/bin"
+  INSTALL_DIR="$HOME/.yen/bin"
 
-REPO=tusharsadhwani/yen
-PLATFORM=$(uname -s)
-ARCH=$(uname -m)
+  REPO=tusharsadhwani/yen
+  PLATFORM=$(uname -s)
+  ARCH=$(uname -m)
 
-if [ $PLATFORM = "Darwin" ]; then
-  PLATFORM="apple-darwin"
-elif [ $PLATFORM = "Linux" ]; then
-  PLATFORM="unknown-linux-musl"
-fi
+  if [ $PLATFORM = "Darwin" ]; then
+    PLATFORM="apple-darwin"
+  elif [ $PLATFORM = "Linux" ]; then
+    PLATFORM="unknown-linux-musl"
+  fi
 
-if [ $ARCH == "arm64" ] || [ $ARCH == "aarch64" ]; then
-  ARCH="aarch64"
-fi
+  if [ $ARCH == "arm64" ] || [ $ARCH == "aarch64" ]; then
+    ARCH="aarch64"
+  fi
 
-BINARY="yen-rs-${ARCH}-${PLATFORM}"
+  BINARY="yen-rs-${ARCH}-${PLATFORM}"
 
-printf "This script will automatically download and install yen for you.\nGetting it from this url: $DOWNLOAD_URL\nThe binary will be installed into '$INSTALL_DIR'\n"
+  printf "This script will automatically download and install yen for you.\nGetting it from this url: $DOWNLOAD_URL\nThe binary will be installed into '$INSTALL_DIR'\n"
 
-if ! hash curl 2> /dev/null; then
-  echo "error: you do not have 'curl' installed which is required for this script."
-  exit 1
-fi
+  # Check if curl or wget is available
+  if hash curl 2>/dev/null; then
+    DOWNLOAD_CMD="curl -SL --progress-bar"
+  elif hash wget 2>/dev/null; then
+    DOWNLOAD_CMD="wget --progress=bar -O"
+  else
+    echo "error: neither 'curl' nor 'wget' found, which are required for this script."
+    exit 1
+  fi
 
-TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/.yen_install.XXXXXXXX")
+  TEMP_FILE=$(mktemp "${TMPDIR:-/tmp}/.yen_install.XXXXXXXX")
 
-cleanup() {
-  rm -f "$TEMP_FILE"
-}
+  cleanup() {
+    rm -f "$TEMP_FILE"
+  }
 
-trap cleanup EXIT
+  trap cleanup EXIT
 
-DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}"
-HTTP_CODE=$(curl -SL --progress-bar "$DOWNLOAD_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
-if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
-  echo "error: '${DOWNLOAD_URL}' is not available"
-  exit 1
-fi
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY}"
+  HTTP_CODE=$($DOWNLOAD_CMD "$TEMP_FILE" "$DOWNLOAD_URL" 2>&1 | grep "HTTP/" | awk '{print $2}')
+  if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
+    echo "error: '${DOWNLOAD_URL}' is not available"
+    exit 1
+  fi
 
-# Move yen to the install directory
-mkdir -p "$INSTALL_DIR"
-mv "$TEMP_FILE" "$INSTALL_DIR/yen"
+  # Move yen to the install directory
+  mkdir -p "$INSTALL_DIR"
+  mv "$TEMP_FILE" "$INSTALL_DIR/yen"
 
-# Download userpath and microvenv too
-USERPATH_URL="https://yen.tushar.lol/userpath.pyz"
-HTTP_CODE=$(curl -SL --progress-bar "$USERPATH_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
-if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
-  echo "error: '${USERPATH_URL}' is not available"
-  exit 1
-fi
-mkdir -p "$INSTALL_DIR"
-mv "$TEMP_FILE" "$INSTALL_DIR/userpath.pyz"
+  # Download userpath and microvenv too
+  USERPATH_URL="https://yen.tushar.lol/userpath.pyz"
+  HTTP_CODE=$($DOWNLOAD_CMD "$TEMP_FILE" "$USERPATH_URL" 2>&1 | grep "HTTP/" | awk '{print $2}')
+  if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
+    echo "error: '${USERPATH_URL}' is not available"
+    exit 1
+  fi
+  mkdir -p "$INSTALL_DIR"
+  mv "$TEMP_FILE" "$INSTALL_DIR/userpath.pyz"
 
-MICROVENV_URL="https://yen.tushar.lol/microvenv.py"
-HTTP_CODE=$(curl -SL --progress-bar "$MICROVENV_URL" --output "$TEMP_FILE" --write-out "%{http_code}")
-if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
-  echo "error: '${MICROVENV_URL}' is not available"
-  exit 1
-fi
-mkdir -p "$INSTALL_DIR"
-mv "$TEMP_FILE" "$INSTALL_DIR/microvenv.py"
+  MICROVENV_URL="https://yen.tushar.lol/microvenv.py"
+  HTTP_CODE=$($DOWNLOAD_CMD "$TEMP_FILE" "$MICROVENV_URL" 2>&1 | grep "HTTP/" | awk '{print $2}')
+  if [ ${HTTP_CODE} -lt 200 ] || [ ${HTTP_CODE} -gt 299 ]; then
+    echo "error: '${MICROVENV_URL}' is not available"
+    exit 1
+  fi
+  mkdir -p "$INSTALL_DIR"
+  mv "$TEMP_FILE" "$INSTALL_DIR/microvenv.py"
 
-
-update_shell() {
+  update_shell() {
     FILE=$1
     LINE=$2
 
     if [ -f "$FILE" ]; then
-        if ! grep -Fxq "$LINE" "$FILE"
-        then
-            echo "Updating '${FILE}'"
-            echo "$LINE" >> "$FILE"
-        fi
+      if ! grep -Fxq "$LINE" "$FILE"; then
+        echo "Updating '${FILE}'"
+        echo "$LINE" >>"$FILE"
+      fi
     fi
+  }
+  case "$(basename "$SHELL")" in
+  bash)
+    if [ -f ~/.bash_profile ]; then
+      BASH_FILE=~/.bash_profile
+    else
+      # Default to bashrc as that is used in non login shells instead of the profile.
+      BASH_FILE=~/.bashrc
+    fi
+    LINE="export PATH=\$PATH:${INSTALL_DIR}"
+    update_shell $BASH_FILE "$LINE"
+    ;;
+
+  fish)
+    LINE="fish_add_path ${INSTALL_DIR}"
+    update_shell ~/.config/fish/config.fish "$LINE"
+    ;;
+
+  zsh)
+    LINE="export PATH=\$PATH:${INSTALL_DIR}"
+    update_shell ~/.zshrc "$LINE"
+    ;;
+
+  *)
+    echo "Unsupported shell: $(basename "$0")"
+    ;;
+  esac
+
+  chmod +x "$INSTALL_DIR/yen"
+
+  echo "Please restart or source your shell."
+
 }
-case "$(basename "$SHELL")" in
-    bash)
-        if [ -f ~/.bash_profile ]; then
-            BASH_FILE=~/.bash_profile
-        else
-            # Default to bashrc as that is used in non login shells instead of the profile.
-            BASH_FILE=~/.bashrc
-        fi
-        LINE="export PATH=\$PATH:${INSTALL_DIR}"
-        update_shell $BASH_FILE "$LINE"
-        ;;
-
-    fish)
-        LINE="fish_add_path ${INSTALL_DIR}"
-        update_shell ~/.config/fish/config.fish "$LINE"
-        ;;
-
-    zsh)
-        LINE="export PATH=\$PATH:${INSTALL_DIR}"
-        update_shell ~/.zshrc "$LINE"
-        ;;
-
-    *)
-        echo "Unsupported shell: $(basename "$0")"
-        ;;
-esac
-
-chmod +x "$INSTALL_DIR/yen"
-
-echo "Please restart or source your shell."
-
-}; __wrap__
+__wrap__


### PR DESCRIPTION
fix: #19 

- Updated the bootstrapping script to use wget when curl is not available.
- A helpful error message if neither curl nor wget is installed.
